### PR TITLE
Enabled acceleration limits, now they work

### DIFF
--- a/magni_bringup/param/base.yaml
+++ b/magni_bringup/param/base.yaml
@@ -39,11 +39,11 @@ ubiquity_velocity_controller:
     x:
       has_velocity_limits    : false
       max_velocity           : 1.0   # m/s
-      has_acceleration_limits: false
-      max_acceleration       : 2.0   # m/s^2
+      has_acceleration_limits: true
+      max_acceleration       : 0.5   # m/s^2
   angular:
     z:
       has_velocity_limits    : false
       max_velocity           : 2.0   # rad/s
-      has_acceleration_limits: false
-      max_acceleration       : 25.0   # rad/s^2
+      has_acceleration_limits: true
+      max_acceleration       : 5.0   # rad/s^2


### PR DESCRIPTION
This PR is in conjunction UbiquityRobotics/ubiquity_motor#23, which fixes UbiquityRobotics/ubiquity_motor#9
