### PR TITLE
Comment out SSL support in the launch file

### DIFF
--- a/magni_demos/launch/speech_control.launch
+++ b/magni_demos/launch/speech_control.launch
@@ -3,9 +3,11 @@
   <include file="$(find magni_teleop)/launch/logitech.launch"/>
 
   <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch">
+<!-- Parameters for SSL support
     <arg name="ssl" value="true" />
     <arg name="certfile" value="/etc/letsencrypt/live/robot.ubiquityrobotics.com/fullchain.pem" />
     <arg name="keyfile" value="/etc/letsencrypt/live/robot.ubiquityrobotics.com/privkey.pem" />
+-->  
   </include>
 
   <node name="tf2_web_republisher" type="tf2_web_republisher" pkg="tf2_web_republisher"/>


### PR DESCRIPTION
Fixes #27 

For SSL support you will have to uncomment and add in the parameters that are correct for your machine.