### PR TITLE
Only exec_depend to avoid pulling in unnecessary dependencies at build-time  

### DIFF
--- a/magni_bringup/package.xml
+++ b/magni_bringup/package.xml
@@ -4,18 +4,17 @@
   <version>0.2.2</version>
   <description>The magni_bringup package</description>
 
-  <maintainer email="rohan@aleopile.com">Rohan Agrawal</maintainer>
-
+  <maintainer email="send2arohan@gmail.com">Rohan Agrawal</maintainer>
   <license>BSD</license>
 
 
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>magni_description</depend>
-  <depend>ubiquity_motor</depend>
-  <depend>robot_state_publisher</depend>
-  <depend>controller_manager</depend>
-  <depend>joint_state_controller</depend>
-  <depend>diff_drive_controller</depend>
+  <exec_depend>magni_description</exec_depend>
+  <exec_depend>ubiquity_motor</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>controller_manager</exec_depend>
+  <exec_depend>joint_state_controller</exec_depend>
+  <exec_depend>diff_drive_controller</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/magni_demos/package.xml
+++ b/magni_demos/package.xml
@@ -8,13 +8,11 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>magni_bringup</depend>
-  <depend>magni_nav</depend>
-  <depend>magni_teleop</depend>
-  <depend>rosbridge_server</depend>
-  <depend>tf2_web_republisher</depend>
-
-
+  <exec_depend>magni_bringup</exec_depend>
+  <exec_depend>magni_nav</exec_depend>
+  <exec_depend>magni_teleop</exec_depend>
+  <exec_depend>rosbridge_server</exec_depend>
+  <exec_depend>tf2_web_republisher</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/magni_description/package.xml
+++ b/magni_description/package.xml
@@ -5,14 +5,13 @@
   <description>The magni_description package</description>
 
   <maintainer email="send2arohan@gmail.com">Rohan Agrawal</maintainer>
-
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>urdf</depend>
-  <depend>xacro</depend>
-  <depend>robot_state_publisher</depend>
-  <depend>joint_state_publisher</depend>
+  <exec_depend>urdf</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
 
   <export></export>
 </package>

--- a/magni_nav/package.xml
+++ b/magni_nav/package.xml
@@ -5,16 +5,14 @@
   <description>The magni_nav package</description>
 
   <maintainer email="send2arohan@gmail.com">Rohan Agrawal</maintainer>
-
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-
-  <depend>fiducial_slam</depend>
-  <depend>fiducial_detect</depend>
-  <depend>aruco_detect</depend>
-  <depend>move_basic</depend>
-  <depend>move_base</depend>
+  <exec_depend>fiducial_slam</exec_depend>
+  <exec_depend>fiducial_detect</exec_depend>
+  <exec_depend>aruco_detect</exec_depend>
+  <exec_depend>move_basic</exec_depend>
+  <exec_depend>move_base</exec_depend>
 
   <!-- We implicitly depend on raspicam_node too -->
 

--- a/magni_robot/package.xml
+++ b/magni_robot/package.xml
@@ -5,7 +5,6 @@
   <description>The magni_robot package</description>
   
   <maintainer email="send2arohan@gmail.com">Rohan Agrawal</maintainer>
-
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>

--- a/magni_teleop/package.xml
+++ b/magni_teleop/package.xml
@@ -1,22 +1,19 @@
 <?xml version="1.0"?>
 <package format="2">
-  <name>magni_teleop</name>
+  <name>magni_nav</name>
   <version>0.2.2</version>
-  <description>The magni_teleop package</description>
+  <description>The magni_nav package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="send2arohan@gmail.com">Rohan Agrawal</maintainer>
-
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>BSD</license>
 
-
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>joy</depend>
-  <depend>teleop_twist_joy</depend>
+  <exec_depend>joy</exec_depend>
+  <exec_depend>teleop_twist_joy</exec_depend>
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
 </package>

--- a/magni_teleop/package.xml
+++ b/magni_teleop/package.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package format="2">
-  <name>magni_nav</name>
+  <name>magni_teleop</name>
   <version>0.2.2</version>
-  <description>The magni_nav package</description>
+  <description>The magni_teleop package</description>
 
   <maintainer email="send2arohan@gmail.com">Rohan Agrawal</maintainer>
   <license>BSD</license>


### PR DESCRIPTION
Fixes #45 

Also make the package.xml files more consistent.

I will run a release after this is merged, and then report on the build time improvement. (Currently it takes 1hr 20min, most of which is pulling deps).

