### PR TITLE
Wait for NTP before launching in Infrastructure mode

### DIFF
--- a/magni_bringup/debian/postinst
+++ b/magni_bringup/debian/postinst
@@ -1,0 +1,6 @@
+#!/bin/sh
+if ! grep -q "makestep" "/etc/chrony/chrony.conf"; then
+  echo "" >> /etc/chrony/chrony.conf
+  echo "# Added by magni_bringup" >> /etc/chrony/chrony.conf
+  echo "makestep 5 1 # Allows chrony to make a step correction once for >5s" >> /etc/chrony/chrony.conf
+fi

--- a/magni_bringup/launch/base.launch
+++ b/magni_bringup/launch/base.launch
@@ -16,7 +16,7 @@
     -->
     <param name="ubiquity_robot_mode" type="string" value="teleop"/>
 
-    <node name="magni_launch_core" pkg="magni_bringup" type="launch_core.py"/>
+    <node name="magni_launch_core" pkg="magni_bringup" type="launch_core.py" output="screen"/>
     <include file="$(find magni_teleop)/launch/logitech.launch" />
     <include file="$(find magni_teleop)/launch/rosbridge.launch" />
 </launch>

--- a/magni_bringup/package.xml
+++ b/magni_bringup/package.xml
@@ -16,6 +16,9 @@
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>diff_drive_controller</exec_depend>
 
+  <!-- Force chrony to be installed -->
+  <exec_depend>chrony</exec_depend>
+
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->

--- a/magni_bringup/scripts/launch_core.py
+++ b/magni_bringup/scripts/launch_core.py
@@ -62,6 +62,7 @@ if __name__ == "__main__":
             if "is connected to" in output:
                 # we are connected to a network
                 subprocess.call(["chronyc", "waitsync", "6"]) # Wait for chrony sync
+                break
     except (RuntimeError, OSError, subprocess.CalledProcessError) as e:
         print "Error calling pifi"
         if (time.time() < 1530403200): # If date before July 1, 2018

--- a/magni_bringup/scripts/launch_core.py
+++ b/magni_bringup/scripts/launch_core.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
 
     print conf
 
-    time.sleep(5)
+    time.sleep(5) # pifi doesn't like being called early in boot
     try:
         timeout = time.time() + 40 # up to 40 seconds
         while (1):

--- a/magni_bringup/scripts/launch_core.py
+++ b/magni_bringup/scripts/launch_core.py
@@ -53,20 +53,20 @@ if __name__ == "__main__":
         while (1):
             if (time.time() > timeout): 
                 print "Timed out"
-                raise RuntimeError # go to default handling
+                raise RuntimeError # go to error handling
             output = subprocess.check_output(["pifi", "status"])
             if "not activated" in output:
                 time.sleep(5)
             if "acting as an Access Point" in output:
+                print "we are in AP mode, don't wait for time"
                 break # dont bother with chrony in AP mode
             if "is connected to" in output:
-                # we are connected to a network
-                subprocess.call(["chronyc", "waitsync", "6"]) # Wait for chrony sync
+                print "we are connected to a network, wait for time"
+                subprocess.call(["chronyc", "waitsync", "20"]) # Wait for chrony sync
                 break
     except (RuntimeError, OSError, subprocess.CalledProcessError) as e:
         print "Error calling pifi"
-        if (time.time() < 1530403200): # If date before July 1, 2018
-            subprocess.call(["chronyc", "waitsync", "6"]) # Wait for chrony sync
+        subprocess.call(["chronyc", "waitsync", "6"]) # Wait up to 60 seconds for chrony
 
     # Ugly, but works 
     # just passing argv doesn't work with launch arguments, so we assign sys.argv


### PR DESCRIPTION
Otherwise the time jump makes things crash.

This also means that the robots use chrony instead of timesyncd.
