### PR TITLE
Add support for reading board version from I2C

### DIFF
--- a/magni_bringup/launch/core.launch
+++ b/magni_bringup/launch/core.launch
@@ -31,12 +31,14 @@
     -->
     <arg name="raspicam_mount" default="forward"/>
     <!-- 
-        This parameter specifies wheter the sonars are
+        This parameter specifies whether the sonars are
         installed or not.
 
         This can be true or false
     -->
     <arg name="sonars_installed" default="false"/>
+
+    <arg name="controller_board_version" default="0"/>
 
     <!-- Launch the URDF for magni -->
     <include file="$(find magni_description)/launch/description.launch">
@@ -55,12 +57,19 @@
 
     <!-- Load the parameters used by the following nodes -->
     <rosparam command="load" file="$(find magni_bringup)/param/base.yaml" />
+    
+    <!-- If a board version was passed in, use it -->
+    <group if="$(eval controller_board_version != 0)">
+	<param name="/ubiquity_motor/controller_board_version" value="$(arg controller_board_version)"/>
+    </group>
+    
     <!-- Launch the roscontrol controllers needed -->
     <node name="controller_spawner" pkg="controller_manager" type="spawner"
         args="ubiquity_velocity_controller ubiquity_joint_publisher"/>
     <!-- Launch the motor node with the topic remapped to standard names -->
     <node name="motor_node" pkg="ubiquity_motor" type="motor_node">
         <remap from="/ubiquity_velocity_controller/cmd_vel" to="/cmd_vel"/>
-        <remap from="/ubiquity_velocity_controller/odom" to="/odom"/>
+	<remap from="/ubiquity_velocity_controller/odom" to="/odom"/>
+
     </node>
 </launch>

--- a/magni_bringup/scripts/launch_core.py
+++ b/magni_bringup/scripts/launch_core.py
@@ -8,13 +8,15 @@
 import sys, os, subprocess, time
 import roslaunch
 import yaml
+import smbus # used for the hw rev stuff
 
 conf_path = "/etc/ubiquity/robot.yaml"
 
 default_conf = \
 {
     'raspicam' : {'position' : 'forward'},
-    'sonars' : 'None'
+    'sonars' : 'None',
+    'motor_controller' : {'board_version' : None}
 }
 
 def get_conf():
@@ -68,10 +70,26 @@ if __name__ == "__main__":
         print "Error calling pifi"
         subprocess.call(["chronyc", "waitsync", "6"]) # Wait up to 60 seconds for chrony
 
+    boardRev = 0
+
+    if conf['motor_controller']['board_version'] == None: 
+        # Code to read board version from I2C
+        # The I2C chip is only present on 5.0 and newer boards
+        try:
+            i2cbus = smbus.SMBus(1)
+            i2cbus.write_byte(0x20, 0xFF)
+            time.sleep(0.2)
+            inputPortBits = i2cbus.read_byte(0x20)
+            boardRev = 49 + (15 - (inputPortBits & 0x0F))
+            print "Got board rev: %d" % boardRev
+        except: 
+            print "Error reading board version from i2c"
+
     # Ugly, but works 
     # just passing argv doesn't work with launch arguments, so we assign sys.argv
     sys.argv = ["roslaunch", "magni_bringup", "core.launch", 
                          "raspicam_mount:=%s" % conf['raspicam']['position'],
-                         "sonars_installed:=%s" % conf['sonars']]
+                         "sonars_installed:=%s" % conf['sonars'],
+                         "controller_board_version:=%d" % boardRev]
 
     roslaunch.main(sys.argv)

--- a/magni_bringup/scripts/launch_core.py
+++ b/magni_bringup/scripts/launch_core.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
             boardRev = 49 + (15 - (inputPortBits & 0x0F))
             print "Got board rev: %d" % boardRev
         except: 
-            print "Error reading board version from i2c"
+            print "Error reading motor controller board version from i2c"
 
     # Ugly, but works 
     # just passing argv doesn't work with launch arguments, so we assign sys.argv


### PR DESCRIPTION
This allows people with newer boards to automatically get features
that are only availible in newer hardware revisions.

Closes #65 