### PR TITLE
Add new camera poses and correct 2 existing poses

### DIFF
--- a/magni_description/urdf/magni.urdf.xacro
+++ b/magni_description/urdf/magni.urdf.xacro
@@ -153,18 +153,32 @@
     </xacro:sonar_hc-sr04>
   </xacro:if>
 
-
   <!-- Define raspicam based on the raspicam_mount argument -->
+  <!-- forward  Legacy tilted slightly upwards              -->
+  <!-- upward   Legacy pointing straight up                 -->
+  <!-- downward Forward and tilted 20 deg downward          -->
+  <!-- ahead    Directly facing forward with no tilt        -->
   <xacro:if value="${raspicam_mount == 'forward'}">
-    <xacro:raspi_camera name="raspicam" connected_to="base_link">
-      <origin xyz="0.035 0.085 0.14" rpy="1.15191731 0 1.5707"/>
-    </xacro:raspi_camera>
+    <xacro:raspicam>
+      <origin xyz="0.050 0.085 0.145" rpy="1.1519 0 1.5707"/>
+    </xacro:raspicam>
   </xacro:if>
   <xacro:if value="${raspicam_mount == 'upward'}">
-    <xacro:raspi_camera name="raspicam" connected_to="base_link">
-      <origin xyz="0.035 0.15 0.14" rpy="0 0 ${pi}"/>
-    </xacro:raspi_camera>
+    <xacro:raspicam>
+      <origin xyz="0.020 0.13 0.160" rpy="0 0 ${pi}"/>
+    </xacro:raspicam>
   </xacro:if>
+  <xacro:if value="${raspicam_mount == 'downward'}">
+    <xacro:raspicam>
+      <origin xyz="0.092 0.073 0.13" rpy="0.00 1.80 0.0"/>
+    </xacro:raspicam>
+  </xacro:if>
+  <xacro:if value="${raspicam_mount == 'ahead'}">
+    <xacro:raspicam>
+      <origin xyz="0.095 0.061 0.10" rpy="0 1.5707 0"/>
+    </xacro:raspicam>
+  </xacro:if>
+
 
 
 </robot>

--- a/magni_description/urdf/magni.urdf.xacro
+++ b/magni_description/urdf/magni.urdf.xacro
@@ -154,11 +154,10 @@
   </xacro:if>
 
   <!-- Define raspicam based on the raspicam_mount argument -->
-  <!-- forward  Legacy tilted slightly upwards              -->
-  <!-- upward   Legacy pointing straight up                 -->
-  <!-- downward Forward and tilted 20 deg downward          -->
+  <!-- forward  Forward and tilted slightly upwards         -->
+  <!-- upward   Pointing straight up                        -->
+  <!-- downward Forward and tilted slightly downward        -->
   <!-- ahead    Directly facing forward with no tilt        -->
-  <!--          It is best to maintain legacy forward name  -->
   <xacro:if value="${raspicam_mount == 'forward'}">
     <xacro:raspicam>
       <origin xyz="0.050 0.085 0.145" rpy="1.1519 0 1.5707"/>

--- a/magni_description/urdf/magni.urdf.xacro
+++ b/magni_description/urdf/magni.urdf.xacro
@@ -158,6 +158,7 @@
   <!-- upward   Legacy pointing straight up                 -->
   <!-- downward Forward and tilted 20 deg downward          -->
   <!-- ahead    Directly facing forward with no tilt        -->
+  <!--          It is best to maintain legacy forward name  -->
   <xacro:if value="${raspicam_mount == 'forward'}">
     <xacro:raspicam>
       <origin xyz="0.050 0.085 0.145" rpy="1.1519 0 1.5707"/>

--- a/magni_description/urdf/magni.urdf.xacro
+++ b/magni_description/urdf/magni.urdf.xacro
@@ -165,7 +165,7 @@
   </xacro:if>
   <xacro:if value="${raspicam_mount == 'upward'}">
     <xacro:raspicam>
-      <origin xyz="0.020 0.13 0.160" rpy="0 0 ${pi}"/>
+      <origin xyz="0.020 0.115 0.160" rpy="0 0 ${pi}"/>
     </xacro:raspicam>
   </xacro:if>
   <xacro:if value="${raspicam_mount == 'downward'}">
@@ -178,7 +178,5 @@
       <origin xyz="0.095 0.061 0.10" rpy="0 1.5707 0"/>
     </xacro:raspicam>
   </xacro:if>
-
-
 
 </robot>


### PR DESCRIPTION
The two poses for **forward and upward** were flawed.  I have changed translations to match robot.

Two new poses have been added.
Add downward which will be for following floor fiducials
Add ahead which will be proposed straight ahead camera option.

Note that to avoid totally breaking a great many things I am using ahead for straight ahead and we will keep using forward for the legacy forward and facing slightly up mount.
You must trust me that this is DEEPLY ingrained into MANY files and we do NOT want to change this just to make the mounting orientations sound 'better' which at best is subjective anyway.

Petro is involved in his area as is Rohan but I don't know if either have a physical robot.
David has a physical robot so I would like SOMEBODY to cross check the new orientations and hopefully verify the change I have made to translation seem valid from measurements off of base link.

Base link is the point half way between wheels in the center of the axel if we had a continuous axel.
