### PR TITLE
Get camera position from extrinsics file if it exists

### DIFF
--- a/magni_bringup/launch/core.launch
+++ b/magni_bringup/launch/core.launch
@@ -37,6 +37,11 @@
         This can be true or false
     -->
     <arg name="sonars_installed" default="false"/>
+    <!--
+    	This parameter specifices the location of the extrinsics
+	calibration for the camera (if it exists).
+    -->
+    <arg name="camera_extrinsics_file" default="-"/>
 
     <arg name="controller_board_version" default="0"/>
 
@@ -44,6 +49,7 @@
     <include file="$(find magni_description)/launch/description.launch">
         <arg name="raspicam_mount" value="$(arg raspicam_mount)"/>
         <arg name="sonars_installed" value="$(arg sonars_installed)"/>
+        <arg name="camera_extrinsics_file" value="$(arg camera_extrinsics_file)"/>
     </include>
 
     <group if="$(arg sonars_installed)">

--- a/magni_bringup/scripts/launch_core.py
+++ b/magni_bringup/scripts/launch_core.py
@@ -85,11 +85,18 @@ if __name__ == "__main__":
         except: 
             print "Error reading motor controller board version from i2c"
 
+    extrinsics_file = '~/.ros/camera_info/extrinsics_%s.yaml' % conf['raspicam']['position']
+    extrinsics_file = os.path.expanduser(extrinsics_file)
+    if not os.path.isfile(extrinsics_file):
+        extrinsics_file = '-'
+
     # Ugly, but works 
     # just passing argv doesn't work with launch arguments, so we assign sys.argv
     sys.argv = ["roslaunch", "magni_bringup", "core.launch", 
                          "raspicam_mount:=%s" % conf['raspicam']['position'],
                          "sonars_installed:=%s" % conf['sonars'],
-                         "controller_board_version:=%d" % boardRev]
+                         "controller_board_version:=%d" % boardRev,
+                         "camera_extrinsics_file:=%s" % extrinsics_file]
 
     roslaunch.main(sys.argv)
+

--- a/magni_description/launch/description.launch
+++ b/magni_description/launch/description.launch
@@ -1,6 +1,7 @@
 <launch>
   <arg name="raspicam_mount" default="forward"/>
   <arg name="sonars_installed" default="true"/>
+  <arg name="camera_extrinsics_file" default="-"/>
 
   <arg name="gui" default="False"/>
   <param name="use_gui" value="$(arg gui)"/>
@@ -8,7 +9,8 @@
       command="$(find xacro)/xacro --inorder
         '$(find magni_description)/urdf/magni.urdf.xacro' 
         raspicam_mount:=$(arg raspicam_mount)
-        sonars_installed:=$(arg sonars_installed)"
+        sonars_installed:=$(arg sonars_installed)
+        camera_extrinsics_file:=$(arg camera_extrinsics_file)"
   />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />

--- a/magni_description/urdf/magni.urdf.xacro
+++ b/magni_description/urdf/magni.urdf.xacro
@@ -7,9 +7,11 @@
   <xacro:arg name="sonars_installed" default="true"/>
   <xacro:property name="sonars_installed" value="$(arg sonars_installed)"/>
 
+  <xacro:arg name="camera_extrinsics_file" default="-"/>
+  <xacro:property name="camera_extrinsics_file" value="$(arg camera_extrinsics_file)"/>
+
   <xacro:property name="wheel_r" value="0.1" />
   <xacro:property name="wheel_xpos" value="0.11" />
-
 
   <xacro:include filename="$(find magni_description)/urdf/magni.transmission.xacro" />
   <xacro:include filename="$(find magni_description)/urdf/magni.gazebo.xacro" />
@@ -154,17 +156,31 @@
   </xacro:if>
 
 
-  <!-- Define raspicam based on the raspicam_mount argument -->
-  <xacro:if value="${raspicam_mount == 'forward'}">
+  <!-- If we are given an extrinsics calibration use that instead of the pre-configured pose -->
+  <xacro:if value="${camera_extrinsics_file != '-'}">
+    <xacro:property name="cam_extrinsics" value="${load_yaml(camera_extrinsics_file)}"/>
+    <xacro:property name="cam_position" value="${cam_extrinsics['position']}"/>
+    <xacro:property name="cam_orientation" value="${cam_extrinsics['orientation']}"/>
+
     <xacro:raspi_camera name="raspicam" connected_to="base_link">
-      <origin xyz="0.035 0.085 0.14" rpy="1.15191731 0 1.5707"/>
+      <origin xyz="${cam_position['x']} ${cam_position['y']} ${cam_position['z']}"
+        rpy="${cam_orientation['r']} ${cam_orientation['p']} ${cam_orientation['y']}"/>
     </xacro:raspi_camera>
   </xacro:if>
-  <xacro:if value="${raspicam_mount == 'upward'}">
-    <xacro:raspi_camera name="raspicam" connected_to="base_link">
-      <origin xyz="0.035 0.15 0.14" rpy="0 0 ${pi}"/>
-    </xacro:raspi_camera>
+  <xacro:if value="${camera_extrinsics_file == '-'}">
+    <!-- Define raspicam based on the raspicam_mount argument -->
+    <xacro:if value="${raspicam_mount == 'forward'}">
+      <xacro:raspi_camera name="raspicam" connected_to="base_link">
+        <origin xyz="0.035 0.085 0.14" rpy="1.15191731 0 1.5707"/>
+      </xacro:raspi_camera>
+    </xacro:if>
+    <xacro:if value="${raspicam_mount == 'upward'}">
+      <xacro:raspi_camera name="raspicam" connected_to="base_link">
+        <origin xyz="0.035 0.15 0.14" rpy="0 0 ${pi}"/>
+      </xacro:raspi_camera>
+    </xacro:if>
   </xacro:if>
+
 
 
 </robot>


### PR DESCRIPTION
This allows for the user to adjust the actual camera position based on
extrinsic calibration.

The file should be in ~/.ros/camera_info/extrinsics_forward.yaml for the forward facing camera.
Example file:
```
position:
        x: 0.0
        y: 1.0
        z: 1.5
orientation:
        r: 0.0
        p: 0
        y: 3.14
```

Fixes: https://github.com/UbiquityRobotics/magni_robot/issues/100