### PR TITLE
Adding support for nav2D flat nav. Adding some existing ROS params to…

### DIFF
--- a/magni_demos/launch/simple_nav_map_flat.launch
+++ b/magni_demos/launch/simple_nav_map_flat.launch
@@ -1,0 +1,24 @@
+<!-- 
+    This launch file brings up a simple navigation system using fiducials [1]
+    and move_basic [2].
+    A special mode that removes roll and pitch from fiducials used for mapping is enabled
+
+    [1] http://wiki.ros.org/fiducials
+    [2] http://wiki.ros.org/move_basic
+-->
+<launch>
+    <!-- 
+        This parameter is used to specify what level of capabilites
+        the robot should have after this launch file.
+
+        Possible values are 'core', 'teleop', and 'navigation'
+
+        Since this launch brings up enough to do navigation, 
+        we set it to 'navigation'.
+    -->
+    <param name="ubiquity_robot_mode" type="string" value="navigation"/> 
+
+    <include file="$(find magni_nav)/launch/move_basic.launch" />
+    <include file="$(find magni_nav)/launch/aruco_nav_map_flat.launch" />
+</launch>
+

--- a/magni_demos/launch/simple_navigation.launch
+++ b/magni_demos/launch/simple_navigation.launch
@@ -6,6 +6,11 @@
     [2] http://wiki.ros.org/move_basic
 -->
 <launch>
+    <arg name="fiducial_len" default="0.140"/>
+    <arg name="read_only_map" default="false"/>
+    <arg name="navigate_flat" default="false"/>
+    <arg name="fiducials_flat" default="false"/>
+    <arg name="verbose_info" default="false"/>
     <!-- 
         This parameter is used to specify what level of capabilites
         the robot should have after this launch file.
@@ -18,6 +23,12 @@
     <param name="ubiquity_robot_mode" type="string" value="navigation"/> 
 
     <include file="$(find magni_nav)/launch/move_basic.launch" />
-    <include file="$(find magni_nav)/launch/aruco.launch" />
+    <include file="$(find magni_nav)/launch/aruco.launch">
+        <arg name="fiducial_len" value="$(arg fiducial_len)" />
+        <arg name="read_only_map" value="$(arg read_only_map)"/>
+        <arg name="navigate_flat" value="$(arg navigate_flat)"/>
+        <arg name="fiducials_flat" value="$(arg fiducials_flat)"/>
+        <arg name="verbose_info" value="$(arg verbose_info)"/>
+    </include>
 </launch>
 

--- a/magni_demos/launch/simple_navigation_flat.launch
+++ b/magni_demos/launch/simple_navigation_flat.launch
@@ -1,0 +1,23 @@
+<!-- 
+    This launch file brings up a simple navigation system using fiducials [1]
+    and move_basic [2].
+
+    [1] http://wiki.ros.org/fiducials
+    [2] http://wiki.ros.org/move_basic
+-->
+<launch>
+    <!-- 
+        This parameter is used to specify what level of capabilites
+        the robot should have after this launch file.
+
+        Possible values are 'core', 'teleop', and 'navigation'
+
+        Since this launch brings up enough to do navigation, 
+        we set it to 'navigation'.
+    -->
+    <param name="ubiquity_robot_mode" type="string" value="navigation"/> 
+
+    <include file="$(find magni_nav)/launch/move_basic.launch" />
+    <include file="$(find magni_nav)/launch/aruco_navigation_flat.launch" />
+</launch>
+

--- a/magni_description/urdf/magni.urdf.xacro
+++ b/magni_description/urdf/magni.urdf.xacro
@@ -176,7 +176,7 @@
     </xacro:if>
     <xacro:if value="${raspicam_mount == 'upward'}">
       <xacro:raspi_camera name="raspicam" connected_to="base_link">
-        <origin xyz="0.035 0.15 0.14" rpy="0 0 ${pi}"/>
+        <origin xyz="0.020 0.115 0.16" rpy="0 0 ${pi}"/>
       </xacro:raspi_camera>
     </xacro:if>
   </xacro:if>

--- a/magni_nav/launch/aruco.launch
+++ b/magni_nav/launch/aruco.launch
@@ -4,6 +4,9 @@
 <launch>
   <arg name="mapping_mode" default="false"/>
   <arg name="fiducial_len" default="0.14"/>
+  <arg name="read_only_map" default="false"/>
+  <arg name="navigate_flat" default="false"/>
+  <arg name="fiducials_flat" default="false"/>
   <arg name="verbose_info" default="false"/>
 
   <!-- camera -->
@@ -27,6 +30,9 @@
     <arg name="base_frame" value="base_footprint"/>
     <arg name="future_date_transforms" value="0.5"/>
     <arg name="verbose_info" value="$(arg verbose_info)"/>
+    <arg name="fiducials_flat" value="$(arg fiducials_flat)"/>
+    <arg name="read_only_map" value="$(arg read_only_map)"/>
+    <arg name="navigate_flat" value="$(arg navigate_flat)"/>
 
     <!-- fiducial_len -->
     <arg name="fiducial_len" value="$(arg fiducial_len)"/>

--- a/magni_nav/launch/aruco_nav_map_flat.launch
+++ b/magni_nav/launch/aruco_nav_map_flat.launch
@@ -1,0 +1,33 @@
+<!--
+   Run the 3d fiducial localization for Nav2D flat floor navigation method
+   A special mode that removes roll and pitch from fiducials used for mapping is enabled
+-->
+<launch>
+  <arg name="mapping_mode" default="false"/>
+  <arg name="fiducial_len" default="0.11"/>
+  <arg name="verbose_info" default="true"/>
+
+  <!-- camera -->
+  <include file="$(find raspicam_node)/launch/arducam2p3mm_1296x972_10fps.launch" />
+
+  <!-- Fiducial detection -->
+  <include file="$(find aruco_detect)/launch/aruco_detect.launch">
+    <arg name="camera" value="/raspicam_node"/>
+    <arg name="image" value="image"/>
+    <arg name="transport" value="compressed"/>
+    <arg name="fiducial_len" value="$(arg fiducial_len)"/>
+    <arg name="verbose_info" value="$(arg verbose_info)"/>
+  </include>
+
+  <!-- Fiducial Navigation For Flat Floor -->
+  <include file="$(find fiducial_slam)/launch/fiducial_slam.launch">
+    <arg name="map_frame" value="map"/>
+    <arg name="odom_frame" value="odom"/>
+    <arg name="base_frame" value="base_link"/>
+    <arg name="fiducial_len" value="$(arg fiducial_len)"/>
+    <arg name="verbose_info" value="$(arg verbose_info)"/>
+    <arg name="read_only_map" value="false"/>
+    <arg name="navigate_flat" value="false"/>
+    <arg name="fiducials_flat" value="true"/>
+  </include>
+</launch>

--- a/magni_nav/launch/aruco_navigation_flat.launch
+++ b/magni_nav/launch/aruco_navigation_flat.launch
@@ -1,34 +1,32 @@
 <!--
-   Run the 3d fiducial localization for a raspi
+   Run the 3d fiducial localization for Nav2D flat floor navigation method
+   This navigation method treats the map.txt file as read only so cannot grow fiducial map.
 -->
 <launch>
   <arg name="mapping_mode" default="false"/>
   <arg name="fiducial_len" default="0.14"/>
-  <arg name="verbose_info" default="false"/>
+  <arg name="verbose_info" default="true"/>
 
   <!-- camera -->
   <include file="$(find raspicam_node)/launch/camerav2_1280x960_10fps.launch" />
-  
+
   <!-- Fiducial detection -->
   <include file="$(find aruco_detect)/launch/aruco_detect.launch">
     <arg name="camera" value="/raspicam_node"/>
     <arg name="image" value="image"/>
     <arg name="transport" value="compressed"/>
-    <arg name="verbose_info" value="$(arg verbose_info)"/>
-
-    <!-- fiducial_len -->
     <arg name="fiducial_len" value="$(arg fiducial_len)"/>
+    <arg name="verbose_info" value="$(arg verbose_info)"/>
   </include>
 
-  <!-- Fiducial slam -->
+  <!-- Fiducial Navigation For Flat Floor -->
   <include file="$(find fiducial_slam)/launch/fiducial_slam.launch">
     <arg name="map_frame" value="map"/>
     <arg name="odom_frame" value="odom"/>
-    <arg name="base_frame" value="base_footprint"/>
-    <arg name="future_date_transforms" value="0.5"/>
-    <arg name="verbose_info" value="$(arg verbose_info)"/>
-
-    <!-- fiducial_len -->
+    <arg name="base_frame" value="base_link"/>
     <arg name="fiducial_len" value="$(arg fiducial_len)"/>
+    <arg name="verbose_info" value="$(arg verbose_info)"/>
+    <arg name="read_only_map" value="true"/>
+    <arg name="navigate_flat" value="true"/>
   </include>
 </launch>

--- a/magni_nav/launch/move_basic.launch
+++ b/magni_nav/launch/move_basic.launch
@@ -5,6 +5,14 @@
         <param name="robot_front_length" value="0.1"/>
         <param name="robot_back_length" value="0.32"/>
 
+	<!-- speed   controls -->
+        <param name="max_linear_velocity" value="0.5"/>
+        <param name="max_angular_velocity" value="1.0"/>
+
+	<!-- End position tolerance -->
+        <param name="linear_tolerance" value="0.03"/>
+        <param name="angular_tolerance" value="0.01"/>
+
 	<!-- lateral control -->
         <param name="min_side_dist" value="0.3"/>
         <param name="max_side_dist" value="2"/>


### PR DESCRIPTION
- Adding launch files for new  'flat' navigation or nav2D mode.
- Additions to move_basic.launch for better visibility from launch file.
  Am trying to set the current software defaults in cpp files OR use what was in prior launch

The required 'flat' nav launches include these:
 High Level Read Only mode:   simple_navigation_flat.launch
 aruco:   aruco_navigation_flat.launch