### PR TITLE
Remove joint publisher, it was redundant with motor_node

### DIFF
--- a/magni_description/launch/description.launch
+++ b/magni_description/launch/description.launch
@@ -3,8 +3,6 @@
   <arg name="sonars_installed" default="true"/>
   <arg name="camera_extrinsics_file" default="-"/>
 
-  <arg name="gui" default="False"/>
-  <param name="use_gui" value="$(arg gui)"/>
   <param name="robot_description" 
       command="$(find xacro)/xacro --inorder
         '$(find magni_description)/urdf/magni.urdf.xacro' 
@@ -13,5 +11,4 @@
         camera_extrinsics_file:=$(arg camera_extrinsics_file)"
   />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
 </launch>


### PR DESCRIPTION
Causes the issue mentioned here. https://forum.ubiquityrobotics.com/t/mutiple-publishers-to-joint-states/441/3

Should be tested on a real robot. The double publish should be resolved, and odometry should be verified to still work.