### PR TITLE
Updated urdf and gazebo topics to match real robot

### DIFF
--- a/magni_description/urdf/magni.urdf.xacro
+++ b/magni_description/urdf/magni.urdf.xacro
@@ -186,7 +186,7 @@
     </xacro:if>
     <xacro:if value="${raspicam_mount == 'downward'}">
       <xacro:raspi_camera name="raspicam" connected_to="base_link">
-        <origin xyz="0.110 0.090 0.455" rpy="3.14159 -0.7854 0.0"/>
+        <origin xyz="0.1 0.090 0.145" rpy="3.14159 -1.25 0.0"/>
       </xacro:raspi_camera>
     </xacro:if>
     <xacro:if value="${raspicam_mount == 'ahead'}">

--- a/magni_description/urdf/sensors/sonar_hc-sr04.xacro
+++ b/magni_description/urdf/sensors/sonar_hc-sr04.xacro
@@ -43,13 +43,13 @@
             <vertical>
               <samples>5</samples>
               <resolution>1.0</resolution>
-              <min_angle>-0.24</min_angle>
-              <max_angle>0.24</max_angle>
+              <min_angle>-0.05</min_angle>
+              <max_angle>0.05</max_angle>
             </vertical>
           </scan>
           <range>
             <min>0.02</min>
-            <max>3.2</max>
+            <max>4.0</max>
             <resolution>0.01</resolution>
           </range>
         </ray>
@@ -58,7 +58,7 @@
           <gaussianNoise>0.015</gaussianNoise>
           <alwaysOn>true</alwaysOn>
           <updateRate>5</updateRate>
-          <topicName>/ubiquity_sonar/${name}</topicName>
+          <topicName>/pi_sonar/${name}</topicName>
           <frameName>${name}</frameName>
           <fov>0.5</fov>
           <radiation>ultrasound</radiation>

--- a/magni_gazebo/launch/magni.launch
+++ b/magni_gazebo/launch/magni.launch
@@ -9,21 +9,23 @@
         <arg name="sonars_installed" value="$(arg sonars_installed)" />
     </include>>
 
-
-    <node name="magni_spawn" pkg="gazebo_ros" type="spawn_model" output="screen"
-          args="-urdf -param robot_description -model magni" />
+    <node name="magni_spawn" pkg="gazebo_ros" type="spawn_model" output="screen" args="-urdf -param robot_description -model magni" />
 
     
-    <!-- Load the parameters used by the following nodes -->
+   <!-- Load the parameters used by the following nodes -->
     <rosparam file="$(find magni_gazebo)/config/magni_controllers.yaml" command="load"/>
     <!-- Launch the roscontrol controllers needed -->
-    <node name="controller_spawner" pkg="controller_manager" type="spawner"
-          args="ubiquity_velocity_controller ubiquity_joint_publisher"/>
-
+    <node name="controller_spawner" pkg="controller_manager" type="spawner" args="ubiquity_velocity_controller ubiquity_joint_publisher"/>
 
     <!-- Topic redirection for compatibility with real robot configuration (core.launch) -->
     <!-- 'topic_tools relay' is used to redirect topics, because remap doesn't work in Gazebo. -->
     <node name="cmd_vel_relay" type="relay" pkg="topic_tools" args="/cmd_vel /ubiquity_velocity_controller/cmd_vel" />
     <node name="odom_relay" type="relay" pkg="topic_tools" args="/ubiquity_velocity_controller/odom /odom" />
+
+    <node name="sonar0_relay" type="relay" pkg="topic_tools" args="/pi_sonar/sonar_0 /sonars" />
+    <node name="sonar1_relay" type="relay" pkg="topic_tools" args="/pi_sonar/sonar_1 /sonars" />
+    <node name="sonar2_relay" type="relay" pkg="topic_tools" args="/pi_sonar/sonar_2 /sonars" />
+    <node name="sonar3_relay" type="relay" pkg="topic_tools" args="/pi_sonar/sonar_3 /sonars" />
+    <node name="sonar4_relay" type="relay" pkg="topic_tools" args="/pi_sonar/sonar_4 /sonars" />
 
 </launch>


### PR DESCRIPTION
A short list of changes:

- flattened sonar cones to prevent always detecting ground 1m away

- increased sonar ranges from 3.2m to 4m, as specified by hardware spec, although it should be noted that the real robot lists the max range as 10m for some reason (?)

- moved "downward" camera pose from Mark's DIY 2×4 to the actual production mount (not exact since I don't have the actual cad model, but it's far better for fiducial detection)

- renamed sonar topics from /ubiquity_sonar to /pi_sonar as is published on the real robot

- set up 5 relays to /sonars topic which is required for move_basic to work at all

I've left the camera resolution as is since it's more project specific, but it should be noted that unlike the v1, the v2 camera is not actually physically capable of recording full FoV at 640x480 as it's currently set up.