### PR TITLE
Handle errors loading robot.yaml

### DIFF
--- a/magni_bringup/scripts/launch_core.py
+++ b/magni_bringup/scripts/launch_core.py
@@ -36,7 +36,13 @@ default_conf = \
 def get_conf():
     try:
         with open(conf_path) as conf_file:
-            conf = yaml.load(conf_file)
+            try:
+                conf = yaml.safe_load(conf_file)
+            except Exception as e:
+                print('Error reading yaml file, using default configuration')
+                print(e)
+                return default_conf
+
             if (conf is None):
                 print('WARN /etc/ubiquity/robot.yaml is empty, using default configuration')
                 return default_conf


### PR DESCRIPTION
If there is an error loading robot.yaml, this uses the default
configuration instead of erroring out and not starting.

Fixes: #118
Bug: https://github.com/UbiquityRobotics/magni_robot/issues/118