### PR TITLE
Changed fiducial len

### DIFF
--- a/magni_demos/launch/fiducial_follow.launch
+++ b/magni_demos/launch/fiducial_follow.launch
@@ -4,7 +4,7 @@
    Expects the magni_bringup base.launch to already be running.
 -->
 <launch>
-    <arg name="fiducial_len" default="0.0982"/>
+    <arg name="fiducial_len" default="0.14"/>
     <arg name="target_fiducial" default="fid49"/>
 
     <!-- Run the Pi Camera at low resolution -->


### PR DESCRIPTION
This pull request should solve issue https://github.com/UbiquityRobotics/magni_robot/issues/125. 

I did a quick research in other repositories and found many more similar cases where the default fiducial len is not set to 14 cm. For example https://github.com/UbiquityRobotics/loki_robot/blob/master/loki_demos/launch/fiducial_follow.launch