### PR TITLE
Max linear velocity increased to 1.1m/s

### DIFF
--- a/magni_bringup/param/base.yaml
+++ b/magni_bringup/param/base.yaml
@@ -38,7 +38,7 @@ ubiquity_velocity_controller:
   linear:
     x:
       has_velocity_limits    : true
-      max_velocity           : 1.0   # m/s
+      max_velocity           : 1.1   # m/s
       has_acceleration_limits: true
       max_acceleration       : 1.1   # m/s^2
   angular:


### PR DESCRIPTION
David and I discussed it a while ago we should set maximum linear velocity to 1.1m/s, because Magni is capable of driving 1.25m/s if I am not wrong.