### PR TITLE
Fixes camera_extrinsics yaml file parsing into magni.urdf.xacro

### DIFF
--- a/magni_description/urdf/magni.urdf.xacro
+++ b/magni_description/urdf/magni.urdf.xacro
@@ -164,8 +164,8 @@
     <xacro:property name="cam_orientation" value="${cam_extrinsics['orientation']}"/>
 
     <xacro:raspi_camera name="raspicam" connected_to="base_link">
-      <origin xyz="${cam_position['x']} ${cam_position['y']} ${cam_position['z']}"
-        rpy="${cam_orientation['r']} ${cam_orientation['p']} ${cam_orientation['y']}"/>
+      <origin xyz="${cam_position[0]} ${cam_position[1]} ${cam_position[2]}"
+        rpy="${cam_orientation[0]} ${cam_orientation[1]} ${cam_orientation[2]}"/>
     </xacro:raspi_camera>
   </xacro:if>
   <xacro:if value="${camera_extrinsics_file == '-'}">


### PR DESCRIPTION
This fixes the parsing error(yaml parameters doesnt get parsed the right way) that pops up when camera_extrinsics file actually exist.