### PR TITLE
Camera Gazebo sensor link confusion elimination

### DIFF
--- a/magni_description/urdf/magni.urdf.xacro
+++ b/magni_description/urdf/magni.urdf.xacro
@@ -181,29 +181,32 @@
     <!-- ahead    Directly facing forward with no tilt        -->
     <xacro:if value="${raspicam_mount == 'forward'}">
       <xacro:raspi_camera name="raspicam" connected_to="base_link">
-        <origin xyz="0.050 0.085 0.135" rpy="1.15191731 0 1.5707"/>
+        <origin xyz="0.050 0.085 0.135" rpy="0 ${-pi/2 - 1.15191731} ${pi}"/>
       </xacro:raspi_camera>
     </xacro:if>
     <xacro:if value="${raspicam_mount == 'upward'}">
       <xacro:raspi_camera name="raspicam" connected_to="base_link">
-        <origin xyz="0.020 0.115 0.155" rpy="0 0 ${pi}"/>
+        <origin xyz="0.020 0.115 0.155" rpy="0 ${-pi/2} ${-pi/2}"/>
       </xacro:raspi_camera>
     </xacro:if>
     <xacro:if value="${raspicam_mount == 'downward'}">
       <xacro:raspi_camera name="raspicam" connected_to="base_link">
-        <origin xyz="0.1 0.090 0.145" rpy="3.14159 -1.25 0.0"/>
+        <origin xyz="0.1 0.090 0.145" rpy="${-pi/2} ${pi/2 - 1.25} 0.0"/>
       </xacro:raspi_camera>
     </xacro:if>
     <xacro:if value="${raspicam_mount == 'ahead'}">
       <xacro:raspi_camera name="raspicam" connected_to="base_link">
-        <origin xyz="0.095 0.061 0.10" rpy="0 1.5707 0"/>
+        <origin xyz="0.095 0.061 0.10" rpy="${pi/2} 0 0"/>
       </xacro:raspi_camera>
     </xacro:if>
   </xacro:if>
- <xacro:if value="${lidar_installed}">
+
+  <!-- Define lidar -->
+  <xacro:if value="${lidar_installed}">
     <xacro:hokuyo_lidar name="laser" connected_to="base_link">
       <origin xyz="0 0.0 0.2" rpy="0 0 0"/>
     </xacro:hokuyo_lidar>
   </xacro:if>
+
 </robot>
 

--- a/magni_description/urdf/magni.urdf.xacro
+++ b/magni_description/urdf/magni.urdf.xacro
@@ -196,7 +196,7 @@
     </xacro:if>
     <xacro:if value="${raspicam_mount == 'ahead'}">
       <xacro:raspi_camera name="raspicam" connected_to="base_link">
-        <origin xyz="0.095 0.061 0.10" rpy="${pi/2} 0 0"/>
+        <origin xyz="0.095 0.061 0.10" rpy="0 0 0"/>
       </xacro:raspi_camera>
     </xacro:if>
   </xacro:if>

--- a/magni_description/urdf/sensors/raspi_camera.xacro
+++ b/magni_description/urdf/sensors/raspi_camera.xacro
@@ -13,7 +13,7 @@
 
     <link name="${name}">
       <visual>
-        <origin xyz="0 0 0" rpy="${pi/2} 0 0" />
+        <origin xyz="0 0 0" rpy="0 0 ${-pi/2}" />
         <geometry>
           <mesh filename="package://magni_description/meshes/sensors/raspi_camera.dae" />
         </geometry>
@@ -26,16 +26,16 @@
       </collision>
     </link>
 
-    <!-- Additional link for camera Gazebo sensor to orient camera direction (it is used only for Gazebo simulation) -->
-    <link name="${name}_gazebo_sensor"/>
-    <joint name="${name}_gazebo_sensor_joint" type="fixed">
+    <!-- Additional link for camera sensor -->
+    <link name="${name}_sensor"/>
+    <joint name="${name}_sensor_joint" type="fixed">
       <parent link="${name}"/>
-      <child link="${name}_gazebo_sensor"/>
-      <origin xyz="0 0 0.012" rpy="${pi/2} ${-pi/2} 0" />
+      <child link="${name}_sensor"/>
+      <origin xyz="0.005 0 0" rpy="${-pi/2} 0 ${-pi/2}" />
     </joint>
 
-    <!-- Gazebo sensor plugin -->
-    <gazebo reference="${name}_gazebo_sensor">
+    <!-- Gazebo sensor plugin. Gazebo sensor is attached to camera link (${name}) but publishes its messages to ${name}_sensor frame. -->
+    <gazebo reference="${name}">
       <sensor type="camera" name="camera1">
         <visualize>false</visualize>
         <update_rate>30.0</update_rate>
@@ -55,10 +55,10 @@
         <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
           <alwaysOn>true</alwaysOn>
           <updateRate>0.0</updateRate>
-          <cameraName>${name}</cameraName>
-          <imageTopicName>/${name}_node/image</imageTopicName>
-          <cameraInfoTopicName>/${name}_node/camera_info</cameraInfoTopicName>
-          <frameName>${name}</frameName>
+          <cameraName></cameraName>
+          <imageTopicName>${name}_node/image</imageTopicName>
+          <cameraInfoTopicName>${name}_node/camera_info</cameraInfoTopicName>
+          <frameName>${name}_sensor</frameName>
           <hackBaseline>0.07</hackBaseline>
           <distortionK1>0.0</distortionK1>
           <distortionK2>0.0</distortionK2>

--- a/magni_description/urdf/sensors/raspi_camera.xacro
+++ b/magni_description/urdf/sensors/raspi_camera.xacro
@@ -26,16 +26,16 @@
       </collision>
     </link>
 
-    <!-- Additional link for camera sensor to orient camera direction -->
-    <link name="${name}_sensor"/>
-    <joint name="${name}_sensor_joint" type="fixed">
+    <!-- Additional link for camera Gazebo sensor to orient camera direction (it is used only for Gazebo simulation) -->
+    <link name="${name}_gazebo_sensor"/>
+    <joint name="${name}_gazebo_sensor_joint" type="fixed">
       <parent link="${name}"/>
-      <child link="${name}_sensor"/>
+      <child link="${name}_gazebo_sensor"/>
       <origin xyz="0 0 0.012" rpy="${pi/2} ${-pi/2} 0" />
     </joint>
 
     <!-- Gazebo sensor plugin -->
-    <gazebo reference="${name}_sensor">
+    <gazebo reference="${name}_gazebo_sensor">
       <sensor type="camera" name="camera1">
         <visualize>false</visualize>
         <update_rate>30.0</update_rate>

--- a/magni_gazebo/launch/rviz_config.rviz
+++ b/magni_gazebo/launch/rviz_config.rviz
@@ -96,7 +96,7 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        raspicam_gazebo_sensor:
+        raspicam_sensor:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -135,7 +135,7 @@ Visualization Manager:
           Value: true
         raspicam:
           Value: true
-        raspicam_gazebo_sensor:
+        raspicam_sensor:
           Value: true
         right_caster_wheel:
           Value: true
@@ -157,7 +157,7 @@ Visualization Manager:
               left_wheel:
                 {}
               raspicam:
-                raspicam_gazebo_sensor:
+                raspicam_sensor:
                   {}
               right_caster_wheel:
                 {}

--- a/magni_gazebo/launch/rviz_config.rviz
+++ b/magni_gazebo/launch/rviz_config.rviz
@@ -10,8 +10,9 @@ Panels:
         - /RobotModel1
         - /TF1
         - /TF1/Frames1
+        - /Image1
       Splitter Ratio: 0.5
-    Tree Height: 634
+    Tree Height: 640
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -20,7 +21,7 @@ Panels:
       - /2D Nav Goal1
       - /Publish Point1
     Name: Tool Properties
-    Splitter Ratio: 0.588679016
+    Splitter Ratio: 0.5886790156364441
   - Class: rviz/Views
     Expanded:
       - /Current View1
@@ -31,6 +32,8 @@ Panels:
     Name: Time
     SyncMode: 0
     SyncSource: LaserScan
+Preferences:
+  PromptSaveOnExit: true
 Toolbars:
   toolButtonStyle: 2
 Visualization Manager:
@@ -42,7 +45,7 @@ Visualization Manager:
       Color: 160; 160; 164
       Enabled: true
       Line Style:
-        Line Width: 0.0299999993
+        Line Width: 0.029999999329447746
         Value: Lines
       Name: Grid
       Normal Cell Count: 0
@@ -93,7 +96,7 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        raspicam_sensor:
+        raspicam_gazebo_sensor:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -103,31 +106,6 @@ Visualization Manager:
           Show Trail: false
           Value: true
         right_wheel:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        sonar_0:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        sonar_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        sonar_2:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        sonar_3:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        sonar_4:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -157,23 +135,13 @@ Visualization Manager:
           Value: true
         raspicam:
           Value: true
-        raspicam_sensor:
+        raspicam_gazebo_sensor:
           Value: true
         right_caster_wheel:
           Value: true
         right_wheel:
           Value: true
-        sonar_0:
-          Value: true
-        sonar_1:
-          Value: true
-        sonar_2:
-          Value: true
-        sonar_3:
-          Value: true
-        sonar_4:
-          Value: true
-      Marker Scale: 0.300000012
+      Marker Scale: 0.30000001192092896
       Name: TF
       Show Arrows: false
       Show Axes: true
@@ -189,21 +157,11 @@ Visualization Manager:
               left_wheel:
                 {}
               raspicam:
-                raspicam_sensor:
+                raspicam_gazebo_sensor:
                   {}
               right_caster_wheel:
                 {}
               right_wheel:
-                {}
-              sonar_0:
-                {}
-              sonar_1:
-                {}
-              sonar_2:
-                {}
-              sonar_3:
-                {}
-              sonar_4:
                 {}
       Update Interval: 0
       Value: true
@@ -259,7 +217,7 @@ Visualization Manager:
       Value: true
     - Class: rviz/Image
       Enabled: false
-      Image Topic: /raspicam_node/image/compressed
+      Image Topic: /raspicam_node/image
       Max Value: 1
       Median window: 5
       Min Value: 0
@@ -281,24 +239,24 @@ Visualization Manager:
       Color: 255; 255; 255
       Color Transformer: Intensity
       Decay Time: 0
-      Enabled: true
+      Enabled: false
       Invert Rainbow: false
       Max Color: 255; 255; 255
-      Max Intensity: 999999
+      Max Intensity: -999999
       Min Color: 0; 0; 0
-      Min Intensity: 1.00055786e-09
+      Min Intensity: 999999
       Name: LaserScan
       Position Transformer: XYZ
       Queue Size: 10
       Selectable: true
       Size (Pixels): 3
-      Size (m): 0.00999999978
+      Size (m): 0.009999999776482582
       Style: Flat Squares
       Topic: /scan
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
-      Value: true
+      Value: false
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -314,7 +272,10 @@ Visualization Manager:
     - Class: rviz/FocusCamera
     - Class: rviz/Measure
     - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
       Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
     - Class: rviz/SetGoal
       Topic: /move_base_simple/goal
     - Class: rviz/PublishPoint
@@ -324,35 +285,35 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 6.03636646
+      Distance: 6.0363664627075195
       Enable Stereo Rendering:
-        Stereo Eye Separation: 0.0599999987
+        Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: -0.2592448
-        Y: 0.171875939
-        Z: -0.29425779
+        X: -0.25924479961395264
+        Y: 0.1718759387731552
+        Z: -0.294257789850235
       Focal Shape Fixed Size: true
-      Focal Shape Size: 0.0500000007
+      Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
-      Near Clip Distance: 0.00999999978
-      Pitch: 0.839794755
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.8397947549819946
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 0.167224169
+      Yaw: 0.16722416877746582
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1003
+  Height: 1025
   Hide Left Dock: false
   Hide Right Dock: true
   Image:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd0000000400000000000002d700000345fc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006100fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000002800000345000000d700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d00610067006500000004870000017a0000001600ffffff000000010000015f00000597fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000006e00000597000000ad00fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000005afc0100000002fb0000000800540069006d00650100000000000007800000030000fffffffb0000000800540069006d00650100000000000004500000000000000000000004a30000034500000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000002d700000347fc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000347000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d006100670065000000020a0000017a0000001600ffffff000000010000015f00000597fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000006e00000597000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073d0000005afc0100000002fb0000000800540069006d006501000000000000073d000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000004600000034700000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -361,6 +322,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: true
-  Width: 1920
-  X: 0
-  Y: 24
+  Width: 1853
+  X: 534
+  Y: 27


### PR DESCRIPTION
Minor refactoring to eliminate confusion with Gazebo camera sensor (issue #140 ).

Gazebo camera sensor has its own link. It is used just in Gazebo simulation to align Gazebo camera sensor with URDF camera link. This link is required because Gazebo camera is aligned with X-axis, but according to ROS convention camera should align with Z-axis.