### PR TITLE
Fixed the camera transport name for fiducial world

### DIFF
--- a/magni_gazebo/launch/fiducials/fiducial_slam_gazebo.launch
+++ b/magni_gazebo/launch/fiducials/fiducial_slam_gazebo.launch
@@ -2,7 +2,7 @@
 
     <include file="$(find aruco_detect)/launch/aruco_detect.launch">
         <arg name="camera" value="/raspicam_node"/>
-        <arg name="image" value="image/compressed"/>
+        <arg name="image" value="image"/>
         <arg name="transport" default="compressed"/>
         <arg name="fiducial_len" value="0.14"/>
         <arg name="dictionary" value="16"/>


### PR DESCRIPTION
Fixed a camera transport topic so fiducial slam works in gazebo

Try it out with
`roslaunch magni_gazebo fiducial_world.launch`