### PR TITLE
Fixed extrinsics folder for gazebo launches, fixed fiducial world spawn

### DIFF
--- a/magni_description/urdf/inertial.xacro
+++ b/magni_description/urdf/inertial.xacro
@@ -30,7 +30,7 @@ OF SUCH DAMAGE.
 -->
 
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-    <property name="M_PI" value="3.1415926535897931" />
+    <xacro:property name="M_PI" value="3.1415926535897931" />
 
     <!-- see https://secure.wikimedia.org/wikipedia/en/wiki/List_of_moment_of_inertia_tensors -->
 

--- a/magni_gazebo/launch/empty_world.launch
+++ b/magni_gazebo/launch/empty_world.launch
@@ -2,14 +2,14 @@
 
     <!-- 
     This string will be taken to search for camera extrinsics yaml file like 
-    $(find magni_description)/param/camera_extrinsics_$(arg camera_position).yaml
+    $(find magni_description)/extrinsics/camera_extrinsics_$(arg camera_position).yaml
     so if that yaml file does not exsist, the xacro file will return "No such file or directory" error
     -->
     <arg name="camera_position" default="forward"/> 
     
     <!-- 
     This string will be taken to search for lidar extrinsics yaml file like 
-    $(find magni_description)/param/lidar_extrinsics_$(arg lidar_position).yaml
+    $(find magni_description)/extrinsics/lidar_extrinsics_$(arg lidar_position).yaml
     so if that yaml file does not exsist, the xacro file will return "No such file or directory" error
     -->
     <arg name="lidar_position" default="top_plate"/>

--- a/magni_gazebo/launch/fiducials/fiducial_world.launch
+++ b/magni_gazebo/launch/fiducials/fiducial_world.launch
@@ -1,7 +1,7 @@
 <launch>
 
     <include file="$(find magni_gazebo)/launch/empty_world.launch">
-        <arg name="raspicam_mount" value="upward"/>
+        <arg name="camera_position" value="upward"/>
         <arg name="sonars_installed" value="false"/>
     </include>
 

--- a/magni_gazebo/launch/magni.launch
+++ b/magni_gazebo/launch/magni.launch
@@ -3,7 +3,7 @@
 
     <!-- 
     This string will be taken to search for camera extrinsics yaml file like 
-    $(find magni_description)/param/camera_extrinsics_$(arg camera_position).yaml
+    $(find magni_description)/extrinsics/camera_extrinsics_$(arg camera_position).yaml
     so if that yaml file does not exsist, the xacro file will return "No such file or directory" error
     Leave empty to disable
     -->
@@ -11,7 +11,7 @@
     
     <!-- 
     This string will be taken to search for lidar extrinsics yaml file like 
-    $(find magni_description)/param/lidar_extrinsics_$(arg lidar_position).yaml
+    $(find magni_description)/extrinsics/lidar_extrinsics_$(arg lidar_position).yaml
     so if that yaml file does not exsist, the xacro file will return "No such file or directory" error
     Leave empty to disable
     -->

--- a/magni_gazebo/launch/magni.launch
+++ b/magni_gazebo/launch/magni.launch
@@ -19,8 +19,8 @@
     
     <arg name="sonars_installed" default="true"/>
     
-    <arg name="lidar_extrinsics_file" value="$(find magni_description)/param/lidar_extrinsics_$(arg lidar_position).yaml"/>
-    <arg name="camera_extrinsics_file" value="$(find magni_description)/param/camera_extrinsics_$(arg camera_position).yaml"/>
+    <arg name="lidar_extrinsics_file" value="$(find magni_description)/extrinsics/lidar_extrinsics_$(arg lidar_position).yaml"/>
+    <arg name="camera_extrinsics_file" value="$(find magni_description)/extrinsics/camera_extrinsics_$(arg camera_position).yaml"/>
 
     <include file="$(find magni_description)/launch/description.launch">
         <arg name="camera_extrinsics_file" value="$(arg camera_extrinsics_file)" />

--- a/magni_gazebo/urdf/fiducials/aruco_marker.xacro
+++ b/magni_gazebo/urdf/fiducials/aruco_marker.xacro
@@ -6,7 +6,7 @@
             <joint name="${prefix}${marker_id}_joint" type="fixed">
                 <parent link="world"/>
                 <child link="${prefix}${marker_id}base_link"/>
-                <insert_block name="origin"/>
+                <xacro:insert_block name="origin"/>
             </joint>
         </xacro:if>
 


### PR DESCRIPTION
Fixes

`[Errno 2] No such file or directory: u'/home/janez/Documents/Projects/ubiquityrobotics/magni_ws/src/magni_robot/magni_description/param/camera_extrinsics_forward.yaml' 
`

Test with executing: 

`roslaunch magni_gazebo empty_world.launch`

then the gazebo should start normaly

also if you try launching 

`roslaunch magni_gazebo fiducial_world.launch`

the robot should be spawned with fiducial markers on the ceiling.