### PR TITLE
Adding updated parameter to match recent ubiquity_motor and also addi…

### DIFF
--- a/magni_bringup/param/base.yaml
+++ b/magni_bringup/param/base.yaml
@@ -1,11 +1,16 @@
 ubiquity_motor:
   controller_loop_rate: 20
-  pid_proportional: 5000
-  pid_integral: 7
+  pid_proportional: 6000
+  pid_integral: 4
   pid_derivative: -110
+  pid_velocity: 0
   pid_denominator: 1000
   pid_moving_buffer_size: 70
-  pid_velocity: 15000
+  pid_control: 0
+  fw_max_pwm: 350
+  wheel_type: "standard"
+  wheel_gear_ratio: 4.294 
+  drive_type: "2wd"
 
 ubiquity_joint_publisher:
   type: "joint_state_controller/JointStateController"


### PR DESCRIPTION
Back down pid velocity to 0.   Add several parameters recently added to ubiquity_motor and set as legacy standard values.      Back off PID I term to 4 from 7 because 7 leads to chatter frequently.   
Adding a recent new parameter of  wheel_gear_ratio that is in progress of adding for use in ubiquity_motor.   This gear ratio is needed because of some 'forced' production changes that we must support. It is being set to legacy default in this PR