### PR TITLE
Update empty_world.launch

### DIFF
--- a/magni_gazebo/launch/empty_world.launch
+++ b/magni_gazebo/launch/empty_world.launch
@@ -51,6 +51,8 @@
 
     <!-- Additional nodes (optional)  -->
 
+    <include file="$(find magni_nav)/launch/move_base.launch"/>
+
 
     <!-- RViz to visualize robot state -->
     <arg unless="$(arg rviz_config)" name="rviz_args" value="" />


### PR DESCRIPTION
Along with the pull request alanfederman-4 this allows various demos that rely on move_base to work in gazebo.

This also will work if move_base is launched in magni_bringup on a real robot.
Unknown if this conflicts with maps made by lasers or sonars.
