### PR TITLE
Change project name in README.md

### DIFF
--- a/magni_description/README.md
+++ b/magni_description/README.md
@@ -1,4 +1,4 @@
-# ROS2_humble
+# ROS2_jazzy
 various nodes as converted to colcon build
 
 for the magni_description, I copied it into a ros2_ws/src, edited CMake.txt and package.xml, and then 


### PR DESCRIPTION
Updated project name from ROS2_humble to ROS2_jazzy in README. I am not sure if this is till true.